### PR TITLE
SA-34-Create readme for project

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) [2025] [Jose Luis Correa Moreno]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - [Features](#features)
 - [Installation steps](#installation-steps)
 - [Built with](#built-with)
-- [Project structure](#project-structure)
+- [Project structure](#summarized-project-structure)
 - [Useful resources](#useful-resources)
 - [License](#license)
 - [Author](#author)
@@ -49,7 +49,7 @@ Main technologies used in this project:
 | **Terraform**    | `v1.11.4`   | Infrastructure as Code (IaC) tool for cloud resource management.       |
 | **CockroachDB**  | `v25.1.6`   | Distributed SQL database for scalable and resilient data storage.      |
 
-## Project structure
+## Summarized project structure
 
 ```bash
 StockWise/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,93 @@
-# StockAPI
+<h1 align="center" id="title">Stock Wise</h1>
+
+<p id="description">StockWise is a web application for visualizing and analyzing stock market analyst ratings. The app fetches stock data from an external API, processes it, stores it in CockRoachDB, and presents it to users through an intuitive UI built with Vue + Tailwind, using the library PrimeVue. The backend is developed in Go, providing efficient data processing capabilities. All required API endpoints consumed by the frontend are deployed on AWS infrastructure, with the entire cloud resources managed through Infrastructure as Code (IaC) using Terraform.</p>
+
+## Table of Contents
+
+- [Demo](#demo)
+- [Features](#features)
+- [Installation steps](#installation-steps)
+- [Built with](#built-with)
+- [Project structure](#project-structure)
+- [Useful resources](#useful-resources)
+- [License](#license)
+- [Author](#author)
+
+## Demo
+
+👉 **[Try StockWise Now](https://stock-wise-khaki.vercel.app)** 👈
+
+## Features
+
+Here're some of the project's best features:
+
+- 📊 **Metrics Dashboard**: Displays total stock ratings tracked and their growth trends over time.
+- 📰 **Recent Ratings Feed**: Stay updated with the latest market analyses and stock ratings.
+- 🌟 **Top Stocks Carousel**: Highlights the top suggested stocks to invest in.
+- 🧮 **Scoring Algorithm**: Identifies the best investment opportunities based on multiple calculations.
+- 📋 **Interactive Ratings Table**: Filter by ticker, company, or analyst, and sort by ticker, company, analyst, or date.
+- 🔍 **Detailed Stock View**: Dive deeper into stock information with an in-depth modal view.
+
+## Installation steps
+
+Each folder (`backend`, `frontend`, `infra`) contains a dedicated `README` file with detailed instructions to help you set up and run the respective part of the project locally. Check them out!
+
+## Built with
+
+Main technologies used in this project:
+
+| **Technology**   | **Version** | **Description**                                                        |
+| ---------------- | ----------- | ---------------------------------------------------------------------- |
+| **Go**           | `v1.24.2`   | Backend programming language for efficient data processing.            |
+| **TypeScript**   | `v5.8.0`    | Strongly typed programming language that builds on JavaScript.         |
+| **Vue**          | `v3.5.13`   | Frontend framework for building a dynamic and reactive user interface. |
+| **Tailwind CSS** | `v4.1.4`    | Utility-first CSS framework for fast UI development.                   |
+| **PrimeVue**     | `v4.3.3`    | Vue component library for UI elements.                                 |
+| **Node.js**      | `v18.19.1`  | JavaScript runtime for server-side and build processes.                |
+| **npm**          | `v9.2.0`    | Package manager for JavaScript dependencies.                           |
+| **AWS CLI**      | `v2.15.58`  | Command-line interface for managing AWS services.                      |
+| **Terraform**    | `v1.11.4`   | Infrastructure as Code (IaC) tool for cloud resource management.       |
+| **CockroachDB**  | `v25.1.6`   | Distributed SQL database for scalable and resilient data storage.      |
+
+## Project structure
+
+```bash
+StockWise/
+├── backend/ # Go server-side code
+│   ├── config/ # Configuration management
+│   ├── internal/ # Internal packages
+│   │   ├── analysis/ # Stock analysis algorithms
+│   │   ├── api/ # API consumer and response handlers
+│   │   ├── db/ # Database interactions
+│   │   ├── functions/ # Lambda function handlers
+│   │   └── repository/ # Db repository pattern implementation
+│   ├── models/ # Data models
+│   └── utils/ # Utility functions
+├── frontend/ # Vue.js client-side code
+│   ├── public/ # Static assets
+│   └── src/ # Source files
+│       ├── components/ # Reusable Vue components
+│       ├── composables/ # Composable functions
+│       ├── types/ # TypeScript type definitions
+│       ├── utils/ # Utility functions
+│       └── views/ # Page components
+└── infra/ # Terraform infrastructure code
+    ├── environments/ # Environment-specific configurations
+    └── modules/ # Reusable Terraform modules
+```
+
+## Useful resources
+
+- [Quickstart with CockroachDB](https://www.cockroachlabs.com/docs/cockroachcloud/quickstart)
+- [PrimeVue Docs](https://primevue.org/vite)
+- [AWS with Terraform](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
+
+## License
+
+> This project is licensed under the MIT License - see the LICENSE file for details.
+
+## Author
+
+<a href="https://github.com/CorreaJose13/StockWise/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=CorreaJose13/StockWise" />
+</a>

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,46 @@
+# StockWise Backend Installation Guide
+
+### Prerequisites
+
+- Go 1.24.2
+- AWS CLI configured with appropiate permissions
+- CockroachDB cluster instance
+
+### Environment Setup
+
+1. Clone the repository:
+
+```sh
+git clone https://github.com/CorreaJose13/StockWise.git
+cd StockWise/backend
+```
+
+2. Create a `.env` file in the root directory with the following variables:
+
+```sh
+DB_URL=your-cockroachdb-connection-string
+API_URL=external-api-given-url
+BEARER_TOKEN=external-api-given-token
+```
+
+3. Install dependencies:
+
+```sh
+go mod download
+```
+
+### Local Development
+
+To run the application locally to fetch the stocks from the API and store them in CockroachDB:
+
+```sh
+go run cmd/stockapi/main.go
+```
+
+### Testing
+
+Run the test availables:
+
+```sh
+go test ./...
+```

--- a/backend/internal/api/response/response.go
+++ b/backend/internal/api/response/response.go
@@ -11,7 +11,7 @@ import (
 var (
 	responseHeaders = map[string]string{
 		"Content-Type":                     "application/json",
-		"Access-Control-Allow-Origin":      "https://stock-wise-khaki.vercel.app/",
+		"Access-Control-Allow-Origin":      "*",
 		"Access-Control-Allow-Credentials": "true",
 		"Access-Control-Allow-Headers":     "Content-Type",
 		"Access-Control-Allow-Methods":     "OPTIONS,POST,GET",

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,41 +1,42 @@
-# frontend
+# StockWise Frontend Installation Guide
 
-This template should help get you started developing with Vue 3 in Vite.
+### Prerequisites
 
-## Recommended IDE Setup
+- Node.js 18.19.1 or higher
+- npm 9.2.0 or higher
+- AWS API Gateway invoke url
 
-[VSCode](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (and disable Vetur).
+## Enviroment Setup
 
-## Type Support for `.vue` Imports in TS
+1. Clone the repository:
 
-TypeScript cannot handle type information for `.vue` imports by default, so we replace the `tsc` CLI with `vue-tsc` for type checking. In editors, we need [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) to make the TypeScript language service aware of `.vue` types.
+```sh
+git clone https://github.com/CorreaJose13/StockWise.git
+cd StockWise/frontend
+```
 
-## Customize configuration
-
-See [Vite Configuration Reference](https://vite.dev/config/).
-
-## Project Setup
+2. Install dependencies:
 
 ```sh
 npm install
 ```
 
-### Compile and Hot-Reload for Development
+2. Create a `.env` file in the root directory with the following variables:
+
+```sh
+VITE_API_BASE_URL=apigateway-base-url(example:https://apigateway-id.region.amazonaws.com/stage)
+```
+
+3. Compile and Hot-Reload for Development
 
 ```sh
 npm run dev
 ```
 
-### Type-Check, Compile and Minify for Production
+4. Type-Check, Compile and Minify for Production
 
 ```sh
 npm run build
-```
-
-### Run Unit Tests with [Vitest](https://vitest.dev/)
-
-```sh
-npm run test:unit
 ```
 
 ### Lint with [ESLint](https://eslint.org/)

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,51 @@
+# StockWise Infrastructure Installation Guide
+
+### Prerequisites
+
+- Terraform 1.11.4 or higher
+- AWS CLI configured with appropiate permissions
+- CockroachDB cluster instance
+- S3 bucket for Terraform state management (this infra uses s3 backend)
+
+### Environment Setup
+
+1. Clone the repository:
+
+```sh
+git clone https://github.com/CorreaJose13/StockWise.git
+cd StockWise/infra/environments/production
+```
+
+2. Create a `state.config` file in the directory with the following variables:
+
+```sh
+bucket=your-bucket-for-state
+region=your-region
+key=your-key
+encrypt=true
+use_lockfile=true
+```
+
+3. Create a `variables.tfvars` file in the directory with the following variables:
+
+```sh
+DB_URL           = your-cockroachdb-connection-string
+api_gateway_name = your-api-gateway-name
+lambda_bucket    = your-bucket-name-to-store-lambda-functions
+```
+
+4.  Configure remote state:
+
+```sh
+terraform init -backend-config=state.config
+```
+
+5. Plan and apply:
+
+```sh
+terraform plan -var-file=variables.tfvars
+terraform apply -var-file=variables.tfvars
+```
+
+> [!NOTE]
+> The infrastructure contains a trigger that always updates the lambda functions defined in `backend` folder, so after code changes to the lambda functions just run `terraform apply` to deploy the updated code.


### PR DESCRIPTION
## What?
* Added an `MIT License` file to the project
* Updated the main `README.md` to provide a detailed project overview, including features, technologies used and project structure. The project has been rebranded from "StockAPI" to "StockWise." 
* Added a backend-specific installation guide, detailing prerequisites, environment setup, and testing steps. 
* Added a frontend-specific installation guide, including environment setup and build instructions. 
* Added an infrastructure-specific installation guide, explaining Terraform setup and deployment processes for AWS resources. 

## Why?
- For officially licensing the software under the MIT License.
- To provide comprehensive setup documentation for each component of the project.

## How?
- Creating a step by step guide to easily setup the back, front and infrastructure of the project.
- Created  an standardized license file using the official MIT License template